### PR TITLE
Fix typo 'briliant'

### DIFF
--- a/textediting/autocorrection/data/en_US.xml
+++ b/textediting/autocorrection/data/en_US.xml
@@ -1674,7 +1674,7 @@
     <item find="beleagured" replace="beleaguered" />
     <item find="beneficary" replace="beneficiary" />
     <item find="bibliogaphy" replace="bibliography" />
-    <item find="briliant" replace="brilliant" />
+    <item find="brilliant" replace="brilliant" />
     <item find="caligraphy" replace="calligraphy" />
     <item find="captial" replace="capital" />
     <item find="certian" replace="certain" />


### PR DESCRIPTION
```
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'brilliant', you typed 'briliant'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
```
